### PR TITLE
chore: upgrade to zig 0.15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 env:
-  ZIG_VERSION: 0.13.0
+  ZIG_VERSION: 0.15.1
 
 jobs:
   check:

--- a/Justfile
+++ b/Justfile
@@ -14,7 +14,7 @@ check:
     zig build check -freference-trace
 
 build:
-    zig build --summary all -freference-trace --femit-docs
+    zig build --summary all -freference-trace
 
 test:
     zig build test --summary all -freference-trace

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -15,7 +15,7 @@
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything
     // with this value.
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.15.0",
     .fingerprint = 0xef890ab9d82cfa34,
 
     // This field is optional.

--- a/src/Dst.zig
+++ b/src/Dst.zig
@@ -21,7 +21,7 @@ pub fn Dst(comptime options: Options) type {
             len: Len,
             header: Header,
         };
-        const alignment = @max(@alignOf(Frontmatter), @alignOf(options.T));
+        const alignment: std.mem.Alignment = .fromByteUnits(@max(@alignOf(Frontmatter), @alignOf(options.T)));
 
         const Self = @This();
 
@@ -74,7 +74,7 @@ pub fn Dst(comptime options: Options) type {
         }
 
         pub fn deinit(self: *Self, allocator: Allocator) void {
-            const raw_bytes: [*]align(alignment) u8 = @alignCast(@ptrCast(self));
+            const raw_bytes: [*]align(alignment.toByteUnits()) u8 = @alignCast(@ptrCast(self));
             const slice_ = raw_bytes[0..bytelen(self.size())];
             allocator.free(slice_);
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated minimum Zig toolchain requirement to 0.15.0
  * CI now uses Zig 0.15.1
  * Removed documentation-emission flag from the build commands

* **Refactor**
  * Reworked build system to use a module-and-library structure for improved modularity and clearer test/check wiring

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->